### PR TITLE
Add python2 back into runtime

### DIFF
--- a/runtime-modules/kb_python_runtime/python-pip-list
+++ b/runtime-modules/kb_python_runtime/python-pip-list
@@ -2,13 +2,10 @@ biopython==1.76
 oauth2
 setuptools
 MySQL-python
-SQLAlchemy
-python-novaclient
 numpy
 matplotlib
 sphinx
 tornado
-rpy2
 beautifulsoup
 httplib2
 flup
@@ -24,7 +21,6 @@ chardet
 oauthlib
 pyasn1
 rsa==4.5
-pyyaml
 jsonschema
 poster
 sphinx-http-domain
@@ -53,7 +49,6 @@ cherrypy
 ipython
 pycolor
 requests_toolbelt
-pandas==0.16
 scikit-learn
 yapsy
 treeinterpreter

--- a/ubuntu-22/modules-core.dat
+++ b/ubuntu-22/modules-core.dat
@@ -1,3 +1,5 @@
 kb_perl_runtime	./build.runtime
+kb_python_runtime	./build.python
+kb_python_runtime	./install-python-packages.sh
 p3_python3	./build.package
 p3_r_runtime_4.2	./build.package


### PR DESCRIPTION
Need python2 to load the pickles for the genome evaluation module.