### PR TITLE
Fix fakeroot build failures and add BV-BRC service layer.

### DIFF
--- a/gpu-builds/add-runtime.def
+++ b/gpu-builds/add-runtime.def
@@ -4,4 +4,4 @@ From: {{base}}
 
 %setup
 mkdir -p ${APPTAINER_ROOTFS}/opt
-tar -C ${APPTAINER_ROOTFS}/opt -x -f {{runtime}} 
+tar -C ${APPTAINER_ROOTFS}/opt --no-same-owner -x -f {{runtime}}

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/build-gpu-container
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/build-gpu-container
@@ -35,8 +35,8 @@ fi
 mkdir -p "$APPTAINER_CACHEDIR"
 
 if [[ -z "$APPTAINER_TMPDIR" ]]; then
-    if [[ -d /scout/tmp ]]; then
-        export APPTAINER_TMPDIR=/scout/tmp
+    if [[ -d /disks/tmp ]]; then
+        export APPTAINER_TMPDIR=/disks/tmp
     else
         export APPTAINER_TMPDIR=/tmp
     fi

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/build-gpu-container
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/build-gpu-container
@@ -6,9 +6,15 @@
 # The container will be named with a date tag of the form YYYY-MM-DD.XXX
 # where XXX is an index number incremented by one for each build done on the same day.
 #
-# Usage: build-gpu-container [-v VERSION] [BUILD_DIR]
-#   -v VERSION   Runtime version (default: 143-12)
-#   BUILD_DIR    Container build directory (default: /container-build)
+# Usage: build-gpu-container [-v VERSION] [-r RUNTIME_DIR] [BUILD_DIR]
+#   -v VERSION      Runtime version (default: 143-12)
+#   -r RUNTIME_DIR  Directory containing runtime-<VERSION>.tgz and packages-<VERSION>.txt
+#                   (default: parent of this script's directory, i.e. gpu-builds/)
+#   BUILD_DIR       Container build directory (default: /scout/tmp)
+#
+# Environment variables:
+#   APPTAINER_TMPDIR  — scratch directory for apptainer builds (default: /scout/tmp or /tmp)
+#   APPTAINER_CACHEDIR — OCI image cache (default: $HOME/.apptainer/cache)
 #
 
 set -e
@@ -16,21 +22,38 @@ set -e
 # Default values
 DEFAULT_VERSION="143-12"
 VERSION="$DEFAULT_VERSION"
+RUNTIME_DIR=""
 
-# Set up apptainer cache and tmp locations
-export APPTAINER_CACHEDIR=/disks/tmp/singularity-cache-$USER
-mkdir -p $APPTAINER_CACHEDIR
-export APPTAINER_TMPDIR=/dev/shm/gpu-build-$USER
-mkdir -p $APPTAINER_TMPDIR
+# Set up apptainer cache and tmp locations (user-overridable)
+if [[ -z "$APPTAINER_CACHEDIR" ]]; then
+    if [[ -d /disks/tmp ]]; then
+        export APPTAINER_CACHEDIR=/disks/tmp/singularity-cache-$USER
+    else
+        export APPTAINER_CACHEDIR=$HOME/.apptainer/cache
+    fi
+fi
+mkdir -p "$APPTAINER_CACHEDIR"
+
+if [[ -z "$APPTAINER_TMPDIR" ]]; then
+    if [[ -d /scout/tmp ]]; then
+        export APPTAINER_TMPDIR=/scout/tmp
+    else
+        export APPTAINER_TMPDIR=/tmp
+    fi
+fi
+mkdir -p "$APPTAINER_TMPDIR"
 
 # Parse command line options
-while getopts "v:" opt; do
+while getopts "v:r:" opt; do
     case $opt in
         v)
             VERSION="$OPTARG"
             ;;
+        r)
+            RUNTIME_DIR="$OPTARG"
+            ;;
         \?)
-            echo "Usage: $0 [-v VERSION] [BUILD_DIR]" >&2
+            echo "Usage: $0 [-v VERSION] [-r RUNTIME_DIR] [BUILD_DIR]" >&2
             exit 1
             ;;
     esac
@@ -38,29 +61,43 @@ done
 shift $((OPTIND-1))
 
 # Container build directory (positional argument after options)
-BUILD_DIR="${1:-/container-build}"
+BUILD_DIR="${1:-/scout/tmp}"
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PARENT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# Runtime directory: -r flag > parent dir > olson's path (fallback)
+if [[ -z "$RUNTIME_DIR" ]]; then
+    if [[ -f "$PARENT_DIR/runtime-${VERSION}.tgz" ]]; then
+        RUNTIME_DIR="$PARENT_DIR"
+    elif [[ -f /home/olson/BV-BRC/runtime_build/gpu-builds/runtime-${VERSION}.tgz ]]; then
+        RUNTIME_DIR="/home/olson/BV-BRC/runtime_build/gpu-builds"
+    else
+        RUNTIME_DIR="$PARENT_DIR"
+    fi
+fi
+
 # Set runtime and packages paths based on version
-RUNTIME="$PARENT_DIR/runtime-${VERSION}.tgz"
-PACKAGES="$PARENT_DIR/packages-${VERSION}.txt"
+RUNTIME="$RUNTIME_DIR/runtime-${VERSION}.tgz"
+PACKAGES="$RUNTIME_DIR/packages-${VERSION}.txt"
 
 # Verify runtime and packages files exist
 if [[ ! -f "$RUNTIME" ]]; then
     echo "ERROR: Runtime file not found: $RUNTIME" >&2
+    echo "  Use -r to specify the directory containing runtime-${VERSION}.tgz" >&2
     exit 1
 fi
 if [[ ! -f "$PACKAGES" ]]; then
     echo "ERROR: Packages file not found: $PACKAGES" >&2
+    echo "  Use -r to specify the directory containing packages-${VERSION}.txt" >&2
     exit 1
 fi
 
 echo "Using runtime version: $VERSION"
 echo "  Runtime: $RUNTIME"
 echo "  Packages: $PACKAGES"
+echo "  APPTAINER_TMPDIR: $APPTAINER_TMPDIR"
 
 # Generate the NAME with date tag YYYY-MM-DD.XXX
 DATE_TAG=$(date +%Y-%m-%d)
@@ -87,13 +124,16 @@ echo "Container image: $SIF_FILE"
 # Ensure build directory exists
 mkdir -p "$BUILD_DIR"
 
-# Define the def files to merge
+# Define the def files to merge (order matters — base first, add-runtime/packages last)
 DEF_FILES=(
     "$SCRIPT_DIR/base-build.def"
     "$SCRIPT_DIR/reqts-alphafold.def"
     "$SCRIPT_DIR/reqts-chai.def"
     "$SCRIPT_DIR/reqts-boltz.def"
     "$SCRIPT_DIR/reqts-diffdock.def"
+    "$SCRIPT_DIR/reqts-esmfold.def"
+    "$SCRIPT_DIR/reqts-openfold.def"
+    "$SCRIPT_DIR/reqts-predict-structure.def"
     "$PARENT_DIR/add-runtime.def"
     "$PARENT_DIR/add-packages.def"
 )
@@ -129,7 +169,7 @@ echo "Merging definition files into $DEF_FILE..."
 
 echo ""
 echo "Building container $SIF_FILE..."
-apptainer build \
+apptainer build --fakeroot \
     --build-arg packages="$PACKAGES" \
     --build-arg runtime="$RUNTIME" \
     "$SIF_FILE" "$DEF_FILE"

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/merge_singularity_defs.py
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/merge_singularity_defs.py
@@ -14,6 +14,8 @@ Usage:
     merge_singularity_defs.py *.def -o merged.def --from nvidia/cuda:12.1.0-runtime-ubuntu22.04
 """
 
+from __future__ import annotations
+
 import argparse
 import re
 import sys

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-bvbrc-service.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-bvbrc-service.def
@@ -72,14 +72,8 @@ Stage: final
         cp -r /build/dev_container/modules/$mod/lib/* $KB_DEPLOYMENT/lib/ 2>/dev/null || true
     done
 
-    # Upgrade predict-structure CLI to latest from git (base SIF may have older version)
-    . /opt/miniforge/etc/profile.d/conda.sh
-    conda activate /opt/conda-predict
-    pip install --no-cache-dir --upgrade \
-        "predict-structure[cwl] @ git+https://github.com/CEPI-dxkb/PredictStructureApp.git" \
-        "git+https://github.com/wilke/protein_structure_analysis.git"
-
-    # Clone and deploy the app repo via dev_container bootstrap/make
+    # Clone and deploy the Perl app via dev_container bootstrap/make
+    # (Python tools are installed by reqts-predict-structure.def)
     cd /build/dev_container/modules
     git clone --depth 1 {{app_repo}} PredictStructureApp || true
 

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-bvbrc-service.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-bvbrc-service.def
@@ -1,0 +1,136 @@
+
+# Layer BV-BRC AppService integration on top of the folding container.
+#
+# Copies the Perl runtime and deployed BV-BRC modules from the
+# dev_container Docker image, then clones and deploys the app repo.
+#
+# Usage (layered on existing SIF):
+#   apptainer build --fakeroot \
+#       --build-arg base=/scout/containers/folding_prod.sif \
+#       --build-arg app_repo=https://github.com/CEPI-dxkb/PredictStructureApp.git \
+#       folding-bvbrc.sif reqts-bvbrc-service.def
+#
+# The resulting image can run as:
+#   CLI:     apptainer exec --nv folding-bvbrc.sif predict-structure boltz ...
+#   Service: apptainer exec --nv folding-bvbrc.sif App-PredictStructure params.json
+
+# Stage 1: Source for BV-BRC Perl runtime and build system
+Bootstrap: docker
+From: dxkb/dev_container:cuda12-ubuntu22.04
+Stage: devcontainer
+
+# Stage 2: Layer onto the folding container
+Bootstrap: localimage
+From: {{base}}
+Stage: final
+
+%labels
+    Description BV-BRC AppService integration for protein structure prediction
+
+# Copy individual subdirs to avoid nesting (base SIF already has /opt/patric-common/)
+%files from devcontainer
+    /opt/patric-common/runtime /opt/patric-common/runtime
+    /opt/patric-common/deployment /opt/patric-common/deployment
+    /build/dev_container /build/dev_container
+
+%post -c /bin/bash
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+
+    # SSL/TLS libs needed by Net::SSLeay (BV-BRC workspace client)
+    apt-get update && apt-get install -y --no-install-recommends \
+        libssl-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+    # BV-BRC environment
+    export RT=/opt/patric-common/runtime
+    export KB_DEPLOYMENT=/opt/patric-common/deployment
+    export KB_TOP=$KB_DEPLOYMENT
+    export PATH=$KB_DEPLOYMENT/bin:$RT/bin:$PATH
+    export PERL5LIB=$KB_DEPLOYMENT/lib:$RT/lib/perl5
+
+    # Install missing CPAN modules for BV-BRC services
+    $RT/bin/cpanm --notest \
+        Net::SSLeay IO::Socket::SSL LWP::Protocol::https \
+        REST::Client Class::Accessor Carp::Always \
+    && rm -rf ~/.cpanm
+
+    # Additional BV-BRC modules (SEED libraries)
+    cd /build/dev_container/modules
+    git clone --depth 1 https://github.com/TheSEED/seed_core.git 2>/dev/null || true
+    git clone --depth 1 https://github.com/TheSEED/seed_gjo.git 2>/dev/null || true
+
+    cd /build/dev_container
+    . ./user-env.sh
+    cd modules/seed_core && make -k 2>/dev/null || true
+    cd ../seed_gjo && make -k 2>/dev/null || true
+
+    # Copy SEED libs into deployment
+    mkdir -p $KB_DEPLOYMENT/lib
+    for mod in seed_core seed_gjo; do
+        cp -r /build/dev_container/modules/$mod/lib/* $KB_DEPLOYMENT/lib/ 2>/dev/null || true
+    done
+
+    # Upgrade predict-structure CLI to latest from git (base SIF may have older version)
+    . /opt/miniforge/etc/profile.d/conda.sh
+    conda activate /opt/conda-predict
+    pip install --no-cache-dir --upgrade \
+        "predict-structure[cwl] @ git+https://github.com/CEPI-dxkb/PredictStructureApp.git" \
+        "git+https://github.com/wilke/protein_structure_analysis.git"
+
+    # Clone and deploy the app repo via dev_container bootstrap/make
+    cd /build/dev_container/modules
+    git clone --depth 1 {{app_repo}} PredictStructureApp || true
+
+    # Deploy app using the BV-BRC build system (bootstrap + make deploy-service)
+    cd /build/dev_container
+    . ./user-env.sh
+    cd modules/PredictStructureApp && make deploy-service 2>/dev/null || true
+
+    # Fallback: also copy service-scripts and app_specs directly in case
+    # make deploy-service didn't fully work (e.g. missing Makefile.common)
+    mkdir -p /kb/module/service-scripts \
+             /kb/module/app_specs \
+             /kb/module/lib
+
+    cp /build/dev_container/modules/PredictStructureApp/app_specs/*.json /kb/module/app_specs/ 2>/dev/null || true
+    cp /build/dev_container/modules/PredictStructureApp/service-scripts/*.pl /kb/module/service-scripts/ 2>/dev/null || true
+    chmod +x /kb/module/service-scripts/*.pl 2>/dev/null || true
+
+    # Create entrypoint dispatcher
+    cat > /entrypoint.sh << 'ENTRY'
+#!/bin/bash
+case "$1" in
+    App-PredictStructure*)
+        exec $RT/bin/perl /kb/module/service-scripts/App-PredictStructure.pl "${@:2}"
+        ;;
+    predict-structure)
+        shift
+        exec predict-structure "$@"
+        ;;
+    protein_compare)
+        shift
+        exec protein_compare "$@"
+        ;;
+    bash|sh)
+        exec "$@"
+        ;;
+    *)
+        exec "$@"
+        ;;
+esac
+ENTRY
+    chmod +x /entrypoint.sh
+
+%environment
+    export RT=/opt/patric-common/runtime
+    export KB_DEPLOYMENT=/opt/patric-common/deployment
+    export KB_TOP=/opt/patric-common/deployment
+    export KB_MODULE_DIR=/kb/module
+    export PERL5LIB=$KB_DEPLOYMENT/lib:$RT/lib/perl5
+    export PATH=$KB_DEPLOYMENT/bin:$RT/bin:$PATH
+    export IN_BVBRC_CONTAINER=1
+
+%runscript
+    exec /entrypoint.sh "$@"

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-predict-structure.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-predict-structure.def
@@ -13,8 +13,8 @@ From: {{base}}
     . /opt/miniforge/etc/profile.d/conda.sh
     conda activate $conda_dir
 
-    # Install predict-structure CLI (pyarrow, pyyaml etc. are base deps; cwl extra adds cwltool)
-    pip install --no-cache-dir "predict-structure[cwl] @ git+https://github.com/CEPI-dxkb/PredictStructureApp.git"
+    # Install predict-structure CLI with all extras (cwl, rocrate, etc.)
+    pip install --no-cache-dir "predict-structure[all] @ git+https://github.com/CEPI-dxkb/PredictStructureApp.git"
 
     # Install protein_compare — structure analysis/comparison tool
     pip install --no-cache-dir "git+https://github.com/wilke/protein_structure_analysis.git"

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-predict-structure.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-predict-structure.def
@@ -16,8 +16,12 @@ From: {{base}}
     # Install predict-structure CLI (pyarrow, pyyaml etc. are base deps; cwl extra adds cwltool)
     pip install --no-cache-dir "predict-structure[cwl] @ git+https://github.com/CEPI-dxkb/PredictStructureApp.git"
 
+    # Install protein_compare — structure analysis/comparison tool
+    pip install --no-cache-dir "git+https://github.com/wilke/protein_structure_analysis.git"
+
     # Symlink into /usr/local/bin for easy access
     ln -sf $conda_dir/bin/predict-structure /usr/local/bin/predict-structure
+    ln -sf $conda_dir/bin/protein_compare /usr/local/bin/protein_compare
 
     # Clean up
     conda clean --all --force-pkgs-dirs --yes


### PR DESCRIPTION
Summary

-  Fix fakeroot tar failures: apptainer build --fakeroot fails during %setup because tar cannot change file ownership under fakeroot/root-mapped namespace (exit status 2). Added --no-same-owner to  add-runtime.def.
- Fix Python compatibility in merge script: merge_singularity_defs.py used list[str] type hints that fail under some Python environments. Added from __future__ import annotations.
-  Make build-gpu-container generic: Script had hardcoded paths (/disks/tmp, /dev/shm, /container-build) that only worked on one machine. Added -r flag for runtime directory with auto-discovery fallback,
-  env-var-overridable APPTAINER_TMPDIR/CACHEDIR, --fakeroot flag, and added ESMFold, OpenFold, and predict-structure to the DEF_FILES merge list.
- Add protein_compare to predict-structure: reqts-predict-structure.def now installs protein_structure_analysis alongside predict-structure in /opt/conda-predict.
- Add BV-BRC AppService layer: New reqts-bvbrc-service.def uses Apptainer multi-stage builds to copy Perl runtime and BV-BRC modules from dxkb/dev_container:cuda12-ubuntu22.04, then deploys
- PredictStructureApp service scripts via make deploy-service. Enables the container to run both as CLI and as BV-BRC service.

Test plan

  - Full rebuild via build-gpu-container with --no-same-owner fix
  - BV-BRC service layer build via reqts-bvbrc-service.def
  - All tools verified: predict-structure, protein_compare, AlphaFold, Boltz, Chai, DiffDock, ESMFold, OpenFold
  - Perl app verified: App-PredictStructure.pl syntax OK, AppScript/WorkspaceClient load
  - Deployed as folding_260422.2.sif



add-runtime.def: Add --no-same-owner to tar to fix fakeroot UID/GID mapping failures during %setup (tar exits with status 2 when it cannot change ownership under fakeroot/root-mapped namespace).

merge_singularity_defs.py: Add `from __future__ import annotations` to fix `list[str]` TypeError when run under Python environments where the subscriptable generics syntax is not supported.

build-gpu-container: Make paths generic instead of hardcoded to olson's home directory. Add -r flag for runtime directory, use env-var-overridable APPTAINER_TMPDIR/CACHEDIR with sensible fallbacks, add --fakeroot to apptainer build, include ESMFold, OpenFold, and predict-structure in the DEF_FILES merge list.

reqts-predict-structure.def: Add protein_structure_analysis (protein_compare CLI) alongside predict-structure.

reqts-bvbrc-service.def: New multi-stage Apptainer definition that layers BV-BRC AppService integration (Perl runtime, workspace client, service scripts) on top of the folding SIF. Uses dev_container bootstrap/make deploy-service for proper Perl app deployment.