### PR TITLE
Fix pip/python path resolution in merged container builds.

### DIFF
--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-alphafold.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-alphafold.def
@@ -125,20 +125,20 @@ EOF
     export PYTHONNOUSERSITE=1
     
     # Upgrade pip first
-    pip install --upgrade pip --no-cache-dir
+    $conda_dir/bin/pip install --upgrade pip --no-cache-dir
     
     # Install requirements
-    pip install -r /app/alphafold/requirements.txt --no-cache-dir
+    $conda_dir/bin/pip install -r /app/alphafold/requirements.txt --no-cache-dir
     
     # Install JAX with CUDA 12.2 support (matching Dockerfile)
-    pip install --upgrade --no-cache-dir \
+    $conda_dir/bin/pip install --upgrade --no-cache-dir \
         jax==0.4.26 \
         jaxlib==0.4.26+cuda12.cudnn89 \
         -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
     
     # Clean up to reduce image size
     conda clean --all --force-pkgs-dirs --yes
-    pip cache purge
+    $conda_dir/bin/pip cache purge
     apt-get autoremove --yes
     apt-get clean
     rm -rf /var/lib/apt/lists/*

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-boltz.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-boltz.def
@@ -9,15 +9,15 @@ From: {{base}}
     
     conda_dir=/opt/conda-boltz
 
-    conda create -p $conda_dir --yes --quiet  python=3.11
+    conda create -p $conda_dir --yes --quiet python=3.11 pip
 
     . /opt/miniforge/etc/profile.d/conda.sh
     conda activate $conda_dir
 
     # Install PyTorch with CUDA 12.1 wheels, then Boltz with same index
     # --extra-index-url ensures boltz[cuda] resolves torch from cu121 too
-    pip install 'torch>=2.2' --index-url https://download.pytorch.org/whl/cu121
-    pip install boltz[cuda] --extra-index-url https://download.pytorch.org/whl/cu121
+    $conda_dir/bin/pip install 'torch>=2.2' --index-url https://download.pytorch.org/whl/cu121
+    $conda_dir/bin/pip install boltz[cuda] --extra-index-url https://download.pytorch.org/whl/cu121
 
     #
     # Models are too large for the container. We separately

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-chai.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-chai.def
@@ -9,15 +9,15 @@ From: {{base}}
     
     conda_dir=/opt/conda-chai
 
-    conda create -p $conda_dir --yes --quiet  python=3.10 
+    conda create -p $conda_dir --yes --quiet  python=3.10 pip
 
     . /opt/miniforge/etc/profile.d/conda.sh
     conda activate $conda_dir
 
     # Install PyTorch with CUDA 12.1 wheels, then Chai with same index
     # --extra-index-url ensures chai-lab resolves torch from cu121 too
-    pip install 'torch>=2.3.1' --index-url https://download.pytorch.org/whl/cu121
-    pip install chai-lab --extra-index-url https://download.pytorch.org/whl/cu121
+    $conda_dir/bin/pip install 'torch>=2.3.1' --index-url https://download.pytorch.org/whl/cu121
+    $conda_dir/bin/pip install chai-lab --extra-index-url https://download.pytorch.org/whl/cu121
 
     #
     # Models are too large for the container. We separately

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-diffdock.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-diffdock.def
@@ -12,50 +12,50 @@ From: {{base}}
 . /opt/miniforge/etc/profile.d/conda.sh
 
     # Create conda environment with Python 3.11
-    conda create -p $conda_dir --yes --quiet python=3.11
+    conda create -p $conda_dir --yes --quiet python=3.11 pip
 
     conda activate $conda_dir
 
     # Ensure setuptools<71 is installed (needed for pkg_resources used by pytorch-lightning)
-    pip install --upgrade pip wheel
-    pip install 'setuptools<71'
+    $conda_dir/bin/pip install --upgrade pip wheel
+    $conda_dir/bin/pip install 'setuptools<71'
 
     # Install conda packages first (openbabel and rdkit work better via conda)
     # Install matplotlib via conda to avoid libstdc++ version mismatch
     conda install --yes --quiet -c conda-forge openbabel rdkit matplotlib
 
     # Install PyTorch 2.1.2 with CUDA 12.1 (H100/H200 compatible)
-    pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 \
+    $conda_dir/bin/pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 \
         --index-url https://download.pytorch.org/whl/cu121
 
     # Install PyTorch Geometric ecosystem
-    pip install torch-geometric==2.4.0
+    $conda_dir/bin/pip install torch-geometric==2.4.0
 
     # Install PyG extensions (pre-compiled for PyTorch 2.1 + CUDA 12.1)
-    pip install torch-scatter torch-sparse torch-cluster torch-spline-conv \
+    $conda_dir/bin/pip install torch-scatter torch-sparse torch-cluster torch-spline-conv \
         -f https://data.pyg.org/whl/torch-2.1.0+cu121.html
 
     # DiffDock core dependencies
-    pip install e3nn==0.5.1 \
+    $conda_dir/bin/pip install e3nn==0.5.1 \
                 pytorch-lightning==2.1.0 \
                 torchmetrics==1.2.0 \
                 fair-esm==1.0.3
 
     # Scientific computing
-    pip install numpy==1.24.3 \
+    $conda_dir/bin/pip install numpy==1.24.3 \
                 scipy==1.11.3 \
                 pandas==2.0.3 \
                 scikit-learn==1.3.2
 
     # Molecular modeling
-    pip install biopython==1.81 \
+    $conda_dir/bin/pip install biopython==1.81 \
                 biopandas==0.4.1 \
                 mdanalysis==2.6.1 \
                 spyrmsd==0.5.2 \
                 prody
 
     # Utilities
-    pip install pyyaml==6.0.1 \
+    $conda_dir/bin/pip install pyyaml==6.0.1 \
                 tqdm==4.66.1 \
                 networkx==3.1 \
                 sympy==1.12 \
@@ -63,16 +63,16 @@ From: {{base}}
                 requests==2.31.0
 
     # Configuration and typing
-    pip install pydantic==1.10.13 \
+    $conda_dir/bin/pip install pydantic==1.10.13 \
                 typing-extensions==4.8.0
 
     # Fix libstdc++ issues: pip packages overwrite conda packages with versions
     # compiled against newer libstdc++. Remove pip versions and reinstall via conda.
-    pip uninstall -y matplotlib rdkit rdkit-pypi || true
+    $conda_dir/bin/pip uninstall -y matplotlib rdkit rdkit-pypi || true
     conda install --yes -c conda-forge matplotlib rdkit --force-reinstall
 
     # Verify rdkit installation
-    python -c "from rdkit import Chem; print('rdkit verification: OK')"
+    $conda_dir/bin/python -c "from rdkit import Chem; print('rdkit verification: OK')"
 
     # Set up conda activation scripts for LD_LIBRARY_PATH
     # This ensures conda's libstdc++ (with GLIBCXX_3.4.31+) is used only when env is active
@@ -99,7 +99,7 @@ EOF
     git checkout v1.1
 
     # Pre-generate SO3/torus cache files (avoids slow first-run computation)
-    cd /opt/diffdock && python -c "from utils.so3 import *; from utils.torus import *"
+    cd /opt/diffdock && $conda_dir/bin/python -c "from utils.so3 import *; from utils.torus import *"
 
     # Download DiffDock-L model weights (single zip containing score_model and confidence_model)
     cd /opt/diffdock

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-esmfold.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-esmfold.def
@@ -9,20 +9,20 @@ From: {{base}}
 
     conda_dir=/opt/conda-esmfold
 
-    conda create -p $conda_dir --yes --quiet python=3.11
+    conda create -p $conda_dir --yes --quiet python=3.11 pip
 
     . /opt/miniforge/etc/profile.d/conda.sh
     conda activate $conda_dir
 
     # Install PyTorch with CUDA
-    pip install 'torch>=2.6' --index-url https://download.pytorch.org/whl/cu124
+    $conda_dir/bin/pip install 'torch>=2.6' --index-url https://download.pytorch.org/whl/cu124
 
     # Install ESMFoldApp (provides esm-fold-hf CLI + torch, transformers, accelerate, biopython)
-    pip install --no-cache-dir "git+https://github.com/wilke/ESMFoldApp.git#subdirectory=esm_hf"
+    $conda_dir/bin/pip install --no-cache-dir "git+https://github.com/wilke/ESMFoldApp.git#subdirectory=esm_hf"
 
     # Clean up
     conda clean --all --force-pkgs-dirs --yes
-    pip cache purge
+    $conda_dir/bin/pip cache purge
 
 %environment
 

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-openfold.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-openfold.def
@@ -13,23 +13,23 @@ From: {{base}}
 
     conda_dir=/opt/conda-openfold
 
-    conda create -p $conda_dir --yes --quiet python=3.11
+    conda create -p $conda_dir --yes --quiet python=3.11 pip
 
     . /opt/miniforge/etc/profile.d/conda.sh
     conda activate $conda_dir
 
     # PyTorch 2.5.1 with cu121 (matches OpenFold's Docker image, compatible with CUDA 12.2)
-    pip install 'torch==2.5.1' --index-url https://download.pytorch.org/whl/cu121
+    $conda_dir/bin/pip install 'torch==2.5.1' --index-url https://download.pytorch.org/whl/cu121
 
     # Install OpenFold 3
-    pip install --no-cache-dir openfold3 --extra-index-url https://download.pytorch.org/whl/cu121
+    $conda_dir/bin/pip install --no-cache-dir openfold3 --extra-index-url https://download.pytorch.org/whl/cu121
 
     # Symlink into /usr/local/bin
     ln -sf $conda_dir/bin/run_openfold /usr/local/bin/run_openfold
 
     # Clean up
     conda clean --all --force-pkgs-dirs --yes
-    pip cache purge
+    $conda_dir/bin/pip cache purge
 
 %environment
 

--- a/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-predict-structure.def
+++ b/gpu-builds/cuda-12.2-cudnn-8.9.6/reqts-predict-structure.def
@@ -8,16 +8,16 @@ From: {{base}}
 
     conda_dir=/opt/conda-predict
 
-    conda create -p $conda_dir --yes --quiet python=3.12
+    conda create -p $conda_dir --yes --quiet python=3.12 pip
 
     . /opt/miniforge/etc/profile.d/conda.sh
     conda activate $conda_dir
 
     # Install predict-structure CLI with all extras (cwl, rocrate, etc.)
-    pip install --no-cache-dir "predict-structure[all] @ git+https://github.com/CEPI-dxkb/PredictStructureApp.git"
+    $conda_dir/bin/pip install --no-cache-dir "predict-structure[all] @ git+https://github.com/CEPI-dxkb/PredictStructureApp.git"
 
     # Install protein_compare — structure analysis/comparison tool
-    pip install --no-cache-dir "git+https://github.com/wilke/protein_structure_analysis.git"
+    $conda_dir/bin/pip install --no-cache-dir "git+https://github.com/wilke/protein_structure_analysis.git"
 
     # Symlink into /usr/local/bin for easy access
     ln -sf $conda_dir/bin/predict-structure /usr/local/bin/predict-structure
@@ -25,7 +25,7 @@ From: {{base}}
 
     # Clean up
     conda clean --all --force-pkgs-dirs --yes
-    pip cache purge
+    $conda_dir/bin/pip cache purge
 
 %environment
     export PATH=/opt/conda-predict/bin:$PATH


### PR DESCRIPTION
When merge_singularity_defs.py combines individual reqts-*.def files into a single %post section, conda activate doesn't reliably put pip on PATH because shell functions from conda.sh don't persist across merged sections.

Two fixes applied to all reqts-*.def files:
- Add pip to conda create so $conda_dir/bin/pip exists immediately
- Use $conda_dir/bin/pip and $conda_dir/bin/python instead of bare pip/python calls for reliable path resolution